### PR TITLE
Odstranit podmínku "datum narození nesmí být v budoucnu"

### DIFF
--- a/app/presenters/UzivatelPresenter.php
+++ b/app/presenters/UzivatelPresenter.php
@@ -369,8 +369,8 @@ class UzivatelPresenter extends BasePresenter
         //http://phpfashion.com/jak-overit-platne-ic-a-rodne-cislo
         $form->addText('jmeno', 'Jméno', 30)->setRequired('Zadejte jméno');
         $form->addText('prijmeni', 'Přijmení', 30)->setRequired('Zadejte příjmení');
-        $form->addDate('datum_narozeni', 'Datum narození:')
-        ->addRule($form::Max, 'Nesmí být v budoucnu', new \Nette\Utils\DateTime('-1 hours'));
+        $form->addDate('datum_narozeni', 'Datum narození:');
+        // ->addRule($form::Max, 'Nesmí být v budoucnu', new \Nette\Utils\DateTime('-1 hours'));
         $form->addText('nick', 'Nick (přezdívka)', 30)->setRequired('Zadejte nickname');
         $form->addText('email', 'Email', 30)->setRequired('Zadejte email')->addRule(Form::Email, 'Musíte zadat platný email');
         $form->addText('email2', 'Sekundární email', 30)->addCondition(Form::Filled)->addRule(Form::Email, 'Musíte zadat platný email');


### PR DESCRIPTION
Několik lidí po nasazení reportuje že nelze editovat uživatele. Nedá se to zreplikovat, všude jinde to funguje. Pomůže prej vymazat cookies wtf?. Vypadá to dost jako blocker takže naslepo odstraňuju podmínku a uvidíme.

Lishticqua:
![image (3)](https://github.com/user-attachments/assets/4d9c73cc-6d84-4a3b-9e63-8fbc260d77e6)

Locutus:
![image (4)](https://github.com/user-attachments/assets/892ce4ed-dbcd-4b6c-9be3-ea8cf919e899)

jenom otevřu usera, dám editovat, vyplním datum, dám uložit > vyfakuje mě to
jenom otevřu usera, dám editovat, nezměním nic, dám uložit > vyfakuje mě to :slightly_smiling_face:
[12:52](https://hkfree.slack.com/archives/DBD6D8KHR/p1734594756551509)
aha, možná nějaký cookies ze staré verze? v anonymním okně to funguje