### PR TITLE
Feature: mazání duplicitních smluv v digisign automaticky

### DIFF
--- a/app/model/Log.php
+++ b/app/model/Log.php
@@ -181,7 +181,9 @@ class Log extends Table
         // Je bezpodminecne nutne mit stejny cas pro vsechny polozky, proto se
         // vytvari uz tady a ne az triggerem v DB!
         $ted = new Nette\Utils\DateTime();
-
+        if (empty($uzivatel_id) & $tabulka == 'Uzivatel') {
+            $uzivatel_id = $tabulka_id;
+        }
         if (empty($uzivatel_id)) {
             $uzivatel_id = $this->userService->getId();
         }


### PR DESCRIPTION
Při generování nový účastnický smlouvy, pokud je tam předchozí nepodepsaná, tak ta nepodepsaná se automaticky zruší.
Předpokládá se že ta starší smlouva obsahuje chyby, proto generujeme novou.
Nebudou pak na připojence chodit zbytečné upomínky z té starší nepodepsané smlouvy.

<img width="478" alt="Screenshot 2025-01-05 at 09 43 40" src="https://github.com/user-attachments/assets/7c5d3d15-a6a4-4a2b-8607-bd34fe6f9c28" />

V detailu té zrušené smlouvy:
<img width="733" alt="Screenshot 2025-01-05 at 09 43 17" src="https://github.com/user-attachments/assets/91c79082-04ce-4ff5-9cf0-184733924015" />
