### PR TITLE
Security: authenticate DigiSign webhook and strengthen app password h…

### DIFF
--- a/app/ApiModule/Presenters/AppPresenter.php
+++ b/app/ApiModule/Presenters/AppPresenter.php
@@ -41,7 +41,12 @@ class AppPresenter extends ApiPresenter
             $this->sendLoginFailed($uid);
         }
 
-        if ($u->heslo_strong_hash === $this->uzivatel->generateStrongHash($heslo)) {
+        $rehashNeeded = false;
+        if ($this->uzivatel->verifyStrongPassword($heslo, $u->heslo_strong_hash, $rehashNeeded)) {
+            // Postupná migrace ze starého (nesoleného SHA-256) na bcrypt hash při úspěšném loginu
+            if ($rehashNeeded) {
+                $u->update(['heslo_strong_hash' => $this->uzivatel->hashStrongPassword($heslo)]);
+            }
             $token = $this->aplikaceToken->createAplikaceToken($uid);
             $this->aplikaceLog->log('app.getToken.successful', array($token->id));
             $this->sendResponse(new JsonResponse(['result' => 'OK', 'token' => $token->token]));

--- a/app/model/Uzivatel.php
+++ b/app/model/Uzivatel.php
@@ -248,6 +248,44 @@ WHERE S.od < NOW() AND (S.do IS NULL OR S.do > NOW()) AND U.systemovy = 0 AND U.
         return (crypt($password, 'hk'));
     }
 
+    /**
+     * Vytvoří bezpečný hash hesla pro uložení do sloupce heslo_strong_hash.
+     * Používá password_hash() (aktuálně bcrypt), tedy solený a pomalý hash.
+     */
+    public function hashStrongPassword($password) {
+        return password_hash($password, PASSWORD_DEFAULT);
+    }
+
+    /**
+     * Ověří heslo proti uloženému hashi.
+     *
+     * Podporuje i historický formát (nesolený SHA-256, 64 hex znaků) kvůli
+     * zpětné kompatibilitě. Pokud byl použit starý formát nebo je potřeba
+     * přehashovat aktuálnějšími parametry, nastaví $rehashNeeded na true –
+     * volající by pak měl uložit nový hash z hashStrongPassword().
+     *
+     * Veškerá porovnání jsou konstantní v čase (hash_equals / password_verify).
+     */
+    public function verifyStrongPassword($password, $storedHash, &$rehashNeeded = false) {
+        $rehashNeeded = false;
+        if ($storedHash === null || $storedHash === '') {
+            return false;
+        }
+        // Starý formát: 64 hex znaků = nesolený SHA-256
+        if (preg_match('/^[0-9a-f]{64}$/i', $storedHash)) {
+            if (hash_equals($storedHash, hash('sha256', $password))) {
+                $rehashNeeded = true;
+                return true;
+            }
+            return false;
+        }
+        if (password_verify($password, $storedHash)) {
+            $rehashNeeded = password_needs_rehash($storedHash, PASSWORD_DEFAULT);
+            return true;
+        }
+        return false;
+    }
+
     public function getNewID() {
         return $this->getConnection()->query('SELECT t1.id+1 AS Free
 FROM Uzivatel AS t1

--- a/app/presenters/UzivatelPresenter.php
+++ b/app/presenters/UzivatelPresenter.php
@@ -582,7 +582,7 @@ class UzivatelPresenter extends BasePresenter
             $values->zalozen = new \DateTime();
             $values->heslo = $this->uzivatel->generateStrongPassword();
             $values->heslo_hash = $this->uzivatel->generateWeakHash($values->heslo);
-            $values->heslo_strong_hash = $this->uzivatel->generateStrongHash($values->heslo);
+            $values->heslo_strong_hash = $this->uzivatel->hashStrongPassword($values->heslo);
             $values->id = $this->uzivatel->getNewID();
 
             $uzivatel = $this->uzivatel->insert($values);

--- a/db/structures/2026-06-11-120000-rozsireni-heslo-strong-hash.sql
+++ b/db/structures/2026-06-11-120000-rozsireni-heslo-strong-hash.sql
@@ -1,0 +1,3 @@
+-- Rozšíření sloupce pro hash hesla, aby se vešly bcrypt (60 znaků) i budoucí
+-- algoritmy z password_hash() (např. argon2id, ~96 znaků). Původně VARCHAR(100).
+ALTER TABLE `Uzivatel` MODIFY `heslo_strong_hash` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_czech_ci NULL;

--- a/www/digisign-webhook/index.php
+++ b/www/digisign-webhook/index.php
@@ -2,6 +2,33 @@
 
 include 'WebhookReceiver.php';
 
+/**
+ * Autentizace webhooku sdíleným tajemstvím.
+ *
+ * Bez tohoto bylo dříve možné webhook zavolat anonymně a podvrhnout události
+ * (podpis/zrušení smlouvy, změnu členství). Tajemství je v env proměnné
+ * DIGISIGN_WEBHOOK_SECRET a musí být součástí URL registrované v DigiSignu
+ * (?secret=...) nebo posláno v hlavičce X-Webhook-Secret.
+ *
+ * Pozn.: Po nasazení je nutné DIGISIGN_WEBHOOK_SECRET nastavit a stejné
+ * tajemství doplnit do URL webhooku v administraci DigiSignu, jinak budou
+ * všechna volání (správně) odmítnuta.
+ */
+$expectedSecret = getenv('DIGISIGN_WEBHOOK_SECRET');
+$providedSecret = $_SERVER['HTTP_X_WEBHOOK_SECRET'] ?? ($_GET['secret'] ?? '');
+
+if (!is_string($expectedSecret) || $expectedSecret === '') {
+    error_log('digisign_webhook: DIGISIGN_WEBHOOK_SECRET neni nastaveno -> odmitam request');
+    http_response_code(503);
+    exit;
+}
+
+if (!is_string($providedSecret) || !hash_equals($expectedSecret, $providedSecret)) {
+    error_log('digisign_webhook: neplatne nebo chybejici tajemstvi -> odmitam request');
+    http_response_code(401);
+    exit;
+}
+
 $body = file_get_contents('php://input');
 // $body = '{"id":"0193b88b-67d0-70c2-a4e6-fed356998bac","event":"envelopeCompleted","name":"envelope.completed","time":"2024-12-12T02:46:04+01:00","entityName":"envelope","entityId":"0193b88a-e045-70c7-ac0f-e6adc93009c3","data":{"status":"completed"},"envelope":{"id":"0193b88a-e045-70c7-ac0f-e6adc93009c3","status":"completed"}}';
 // $body = '{"id":"0193b7bc-3bee-7393-b19d-02c49b5781a9","event":"envelopeSent","name":"envelope.sent","time":"2024-12-11T22:59:46+01:00","entityName":"envelope","entityId":"0193b88a-e045-70c7-ac0f-e6adc93009c3","data":{"status":"sent"},"envelope":{"id":"0193b7bc-1797-70f6-a095-231c750d3487","status":"sent"}}';


### PR DESCRIPTION
…ashing

- digisign-webhook: require shared secret (DIGISIGN_WEBHOOK_SECRET) via X-Webhook-Secret header or ?secret= query, compared with hash_equals; fail closed when unset. Previously the webhook processed unsigned payloads anonymously, allowing forged contract/membership events.
- Uzivatel: add hashStrongPassword()/verifyStrongPassword() using password_hash (bcrypt) with constant-time verification and transparent legacy SHA-256 fallback signalling rehash.
- AppPresenter getToken: verify via verifyStrongPassword and upgrade legacy hashes to bcrypt on successful login (gradual migration, no password reset).
- UzivatelPresenter: store bcrypt heslo_strong_hash for new users.
- Migration: widen Uzivatel.heslo_strong_hash to VARCHAR(255) for future password_hash algorithms.